### PR TITLE
when equal version, instead of fetching  from shm 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 t/servroot/*
 go-test
+.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 t/servroot/*
+go-test

--- a/lib/resty/sync.lua
+++ b/lib/resty/sync.lua
@@ -173,8 +173,12 @@ function _M.get_version(self, tag)
 
     local shm = ngx_shared[self.shm]
     local shm_version, err = shm:get(task.shm_version_key)
+    if err then
+        return nil, err
+    end
+
     if is_null(shm_version) then
-        return nil, "no version" .. err
+        return nil, "no version"
     end
 
     if shm_version == task.version then
@@ -183,8 +187,11 @@ function _M.get_version(self, tag)
 
     -- update data 
     local data, err = shm:get(task.shm_data_key)
+    if err then
+        return nil, err
+    end
     if is_null(data) then
-        return nil, "no data" .. err
+        return nil, "no data"
     end
 
     task.version = shm_version
@@ -207,9 +214,12 @@ function _M.get_data(self, tag)
     local task = self.tasks[id]
 
     local shm = ngx_shared[self.shm]
-    local shm_version = shm:get(task.shm_version_key)
+    local shm_version, err = shm:get(task.shm_version_key)
+    if err then
+        return nil, err
+    end
     if is_null(shm_version) then
-        return nil, "no version" .. err
+        return nil, "no version"
     end
 
     -- equal version, no need fetch from shdict
@@ -218,8 +228,11 @@ function _M.get_data(self, tag)
     end
 
     local data, err = shm:get(task.shm_data_key)
+    if err then
+        return nil, err
+    end
     if is_null(data) then
-        return nil, "no data" .. err
+        return nil, "no data"
     end
 
     task.version = shm_version

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1,6 +1,10 @@
 use lib 'lib';
 use Test::Nginx::Socket 'no_plan';
 
+master_on();
+workers(4);
+log_level("error");
+no_long_string();
 run_tests();
 
 __DATA__
@@ -11,6 +15,7 @@ __DATA__
 
 lua_shared_dict sync 5m;
 lua_shared_dict locks 1m;
+lua_package_path "/home/ke/test/web_server/nginx-1.11.2/lua/lib/?.lua;/home/ke/test/web_server/lua-resty-lib/lua-resty-sync/lib/?.lua;;";
 
 init_worker_by_lua_block {
     local sync = require "resty.sync"
@@ -113,3 +118,303 @@ third time, task ex1, data: data 4 and version: version 3
 
 --- no_error_log
 [error]
+
+
+=== TEST 2: mutil tasks register on one sync
+--- http_config
+
+lua_shared_dict sync 5m;
+lua_shared_dict locks 1m;
+lua_package_path "/home/ke/test/web_server/nginx-1.11.2/lua/lib/?.lua;/home/ke/test/web_server/lua-resty-lib/lua-resty-sync/lib/?.lua;;";
+
+init_worker_by_lua_block {
+    local syncer = require "resty.sync"
+
+    local sync, err = syncer.new(2, "sync")
+    if not sync then
+        ngx.log(ngx.ERR, "failed to create sync: ", err)
+        return
+    end
+
+    local data, version = 0, 0
+    local callback_task1 = function(mode)
+        if mode == syncer.ACTION_DATA then
+            data = data + 1
+            return data  
+         else
+            version = version + 1
+            return version
+         end
+    end
+
+    local data, version = 0, 0
+    local callback_task2 = function(mode)
+        if mode == syncer.ACTION_DATA then
+            data = data + 2
+            return data  
+         else
+            version = version + 1
+            return version
+         end
+    end
+
+
+
+    local ok, err = sync.register(sync, callback_task1, "task1")
+    if not ok then
+        ngx.log(ngx.ERR, "failed to register task1: ", err)
+        return
+    end
+
+    local ok, err = sync.register(sync, callback_task2, "task2")
+    if not ok then
+        ngx.log(ngx.ERR, "failed to register task2: ", err)
+        return
+    end
+
+    sync.start(sync)
+
+    SYNC = sync
+
+}
+
+--- config
+    location =/t {
+        content_by_lua_block {
+            local syncer = require "resty.sync"
+            local sync = SYNC
+
+            local task1_tag = "task1"
+            local task2_tag = "task2"
+
+
+            local data1, err = sync.get_data(sync, task1_tag)
+            if not data1 then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task1: ", data1)
+
+            local data2, err = sync.get_data(sync, task2_tag)
+            if not data2 then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task2: ", data2)
+
+            ngx.flush(true)
+
+
+            ngx.sleep(0.1)
+
+            local data, err = sync.get_data(sync, task1_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+            ngx.say("data from task1: ", data)
+
+            local data, err = sync.get_data(sync, task2_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+            ngx.say("data from task2: ", data)
+
+            ngx.flush(true)
+
+            ngx.sleep(2)
+
+            local data, err = sync.get_data(sync, task1_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task1: ", data)
+
+            local data, err = sync.get_data(sync, task2_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task2: ", data)
+            ngx.flush(true)
+
+        }
+    }
+
+--- request
+    GET /t
+
+--- response_body
+data from task1: 1
+data from task2: 2
+data from task1: 1
+data from task2: 2
+data from task1: 2
+data from task2: 4
+
+
+--- no_error_log
+[error]
+
+
+=== TEST 3: mutil tasks register on mutil sync
+--- http_config
+
+lua_shared_dict sync 5m;
+lua_shared_dict locks 1m;
+lua_package_path "/home/ke/test/web_server/nginx-1.11.2/lua/lib/?.lua;/home/ke/test/web_server/lua-resty-lib/lua-resty-sync/lib/?.lua;;";
+
+init_worker_by_lua_block {
+    local syncer = require "resty.sync"
+
+    local sync1, err = syncer.new(1, "sync")
+    if not sync1 then
+        ngx.log(ngx.ERR, "failed to create sync: ", err)
+        return
+    end
+
+    local sync2, err = syncer.new(2, "sync")
+    if not sync2 then
+        ngx.log(ngx.ERR, "failed to create sync: ", err)
+        return
+    end
+
+    local data, version = 0, 0
+    local callback_task1 = function(mode)
+        if mode == syncer.ACTION_DATA then
+            data = data + 0.1
+            return data  
+         else
+            version = version + 1
+            return version
+         end
+    end
+
+    local data, version = 0, 0
+    local callback_task2 = function(mode)
+        if mode == syncer.ACTION_DATA then
+            data = data + 1
+            return data  
+         else
+            version = version + 1
+            return version
+         end
+    end
+
+    local ok, err = sync1.register(sync1, callback_task1, "task1")
+    if not ok then
+        ngx.log(ngx.ERR, "failed to register task1: ", err)
+        return
+    end
+
+    local ok, err = sync2.register(sync2, callback_task2, "task2")
+    if not ok then
+        ngx.log(ngx.ERR, "failed to register task2: ", err)
+        return
+    end
+
+    sync1.start(sync1)
+    sync2.start(sync2)
+
+    SYNC1 = sync1
+    SYNC2 = sync2
+
+}
+
+--- config
+    location =/t {
+        content_by_lua_block {
+            local syncer = require "resty.sync"
+            local sync1 = SYNC1
+            local sync2 = SYNC2
+
+            local task1_tag = "task1"
+            local task2_tag = "task2"
+
+
+            local data1, err = sync1.get_data(sync1, task1_tag)
+            if not data1 then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task1: ", data1)
+
+            local data2, err = sync2.get_data(sync2, task2_tag)
+            if not data2 then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task2: ", data2)
+
+            ngx.flush(true)
+
+
+            ngx.sleep(0.1)
+
+            local data, err = sync1.get_data(sync1, task1_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+            ngx.say("data from task1: ", data)
+
+            local data, err = sync2.get_data(sync2, task2_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+            ngx.say("data from task2: ", data)
+
+            ngx.flush(true)
+
+            ngx.sleep(2)
+
+            local data, err = sync1.get_data(sync1, task1_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task1: ", data)
+
+            local data, err = sync2.get_data(sync2, task2_tag)
+            if not data then
+                ngx.log(ngx.ERR, "failed to get data: ", err)
+                ngx.say("failed")
+            end
+                
+            ngx.say("data from task2: ", data)
+            ngx.flush(true)
+
+        }
+    }
+
+--- request
+    GET /t
+
+--- response_body
+data from task1: 0.1
+data from task2: 1
+data from task1: 0.1
+data from task2: 1
+data from task1: 0.3
+data from task2: 2
+
+
+--- no_error_log
+[error]
+
+
+
+
+
+
+


### PR DESCRIPTION
version should be play it's role  

plus: 
self.owner may not be accurate when there are mutil timer task in on syner instance , so delete it  . 